### PR TITLE
Remove redundant check

### DIFF
--- a/django_super_deduper/merge.py
+++ b/django_super_deduper/merge.py
@@ -153,8 +153,6 @@ class MergedModelInstance(object):
             for field in model_meta.editable_fields:
                 primary_value = getattr(primary_object, field.name)
                 alias_value = getattr(alias_object, field.name)
-                if primary_value == alias_value:
-                    continue
                 
                 logger.debug(f'Primary {field.name} has value: {primary_value}, '
                              f'Alias {field.name} has value: {alias_value}')


### PR DESCRIPTION
We decided this is redundant, only advantage is to not have the logging but it's too little for keeping it.